### PR TITLE
#1 Fixing no Enum validation error raised if type string specified

### DIFF
--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -35,6 +35,7 @@ module.exports = function enjoi(schema, options) {
             return resolve(resolveref(current.$ref));
         }
 
+        //if no type is specified, just enum
         if (current.enum) {
             return Joi.any().valid(current.enum);
         }
@@ -180,6 +181,10 @@ module.exports = function enjoi(schema, options) {
     function string(current) {
         var joischema = Joi.string();
         
+        if (current.enum) {
+            return Joi.any().valid(current.enum);
+        }
+
         switch (current.format) {
             case 'date':
             case 'date-time':

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -367,7 +367,7 @@ Test('types', function (t) {
     });
 
     t.test('enum', function (t) {
-        t.plan(3);
+        t.plan(5);
 
         var schema = Enjoi({
             'enum': ['A', 'B']
@@ -377,6 +377,19 @@ Test('types', function (t) {
             t.ok(!error, 'no error.');
         });
 
+        Joi.validate('B', schema, function (error, value) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate('C', schema, function (error, value) {
+            t.ok(error, 'error.');
+        });
+        
+        schema = Enjoi({
+            type: 'string',
+            'enum': ['A', 'B']
+        });
+        
         Joi.validate('B', schema, function (error, value) {
             t.ok(!error, 'no error.');
         });


### PR DESCRIPTION
Enum support was previously partial. Enum is always provided with type: string, and only the case where the type was not specified was handled. This is fixed now.
